### PR TITLE
Fulfillment

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
   "main": "main.js",
   "dependencies": {
     "coffee-script": "^1.8.0",
-    "azure-storage": "^0.4.2",
-    "lodash": "^3.6.0"
+    "lodash": "^3.6.0",
+    "azure-storage": "~0.6.0",
+    "bluebird": "~2.10.1"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "main": "main.js",
   "dependencies": {
     "coffee-script": "^1.8.0",
-    "azure-storage": "^0.4.2",
-    "lodash": "^3.6.0"
+    "lodash": "^3.6.0",
+    "azure-storage": "~0.6.0"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -1,20 +1,23 @@
 azure = require("azure-storage")
+Promise = require("bluebird")
+Promise.promisifyAll azure
 
 module.exports = (request, response) =>
   console.log new Date()
   console.log JSON.stringify request
   console.log "----------"
-  
+
   enqueue = (message) =>
     azure
       .createQueueService process.env.STORAGE_NAME, process.env.STORAGE_KEY
-      .createMessage process.env.QUEUE_NAME, JSON.stringify(message), =>
-  
-  end = =>
-    response.writeHead 200, { "Content-Type": "text/plain" }
-    response.end "ok"
+      .createMessageAsync process.env.QUEUE_NAME, JSON.stringify(message)
 
-  #---
+##########################
 
   enqueue request
-  end()
+  .then (algo) ->
+    response.writeHead 200, { "Content-Type": "text/plain" }
+    response.end()
+  .catch (err) ->
+    response.writeHead err.statusCode, { "Content-Type": "application/json" }
+    response.end JSON.stringify err

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -8,15 +8,16 @@ module.exports = (request, response) =>
   console.log "----------"
 
   enqueue = (message) =>
-    azure
-      .createQueueService process.env.STORAGE_NAME, process.env.STORAGE_KEY
-      .createMessageAsync process.env.QUEUE_NAME, JSON.stringify(message)
+    service = azure.createQueueService process.env.STORAGE_NAME, process.env.STORAGE_KEY
+
+    service.createQueueIfNotExistsAsync process.env.QUEUE_NAME
+    .then -> service.createMessageAsync process.env.QUEUE_NAME, JSON.stringify(message)
 
 ##########################
 
   enqueue request
   .then (algo) ->
-    response.writeHead 200, { "Content-Type": "text/plain" }
+    response.writeHead 200
     response.end()
   .catch (err) ->
     response.writeHead err.statusCode, { "Content-Type": "application/json" }


### PR DESCRIPTION
[Finishes #97761028](https://www.pivotaltracker.com/story/show/97761028)

Si bien esta story fue mucho de configuraciones y cosas ~~pajas~~ locas de azure, no tengo un buen PR para que vean. Pero cuento un poco todo lo que hice:
- Toqué un poco este proyecto para que:
  - Cree la _Queue_ en caso que no exista, y
  - Devuelva el error en caso de que no pueda poner le mensaje en la cola.
- Se creó un website para [meli-fulfillment-async](https://manage.windowsazure.com/@andreskirgmail.onmicrosoft.com#Workspaces/WebsiteExtension/Website/meli-fulfillment-async/configure) que apunta a esta branch (fulfillment). **Si mergeamos esto a master habría que cambiar eso y, posiblemente, RENOMBRAR ESTE REPO para que no diga _producteca_**.
- Se agregó un [webjob en fulfillment](https://github.com/Parsimotion/fulfillment/tree/development/App_Data/jobs/continuous/fulfillmentWebjob) que consume dichos mensajes y tira las requests. No pude hacer PR porque necesitaba que se deploye a azure, así que pushié directo a development. Si ven los [commits](https://github.com/Parsimotion/fulfillment/commits/development) se van a dar cuenta que me estuve peleando bastante: detallo al final.
- Creé un proyecto [massive-operations-webjob](https://github.com/Parsimotion/massive-operations-webjob) que sirve para leer los mensajes anteriores y ejecutar la request. Ya se encuentra en [npm](https://www.npmjs.com/package/massive-operations-webjob).
- El proyecto [meli-fulfillment-almex](https://manage.windowsazure.com/@andreskirgmail.onmicrosoft.com#Workspaces/WebsiteExtension/Website/meli-fulfillment-almex%28development%29/configure) ahora apunta a meli-fulfillment-async.
- Agregué este proyecto a [Semaphore](https://semaphoreci.com/producteca/producteca-api-async-3) para que sincronice con Pivotal.
#### Cosas malas
- No pude poner al massive-operations-webjob como dependencia en fulfillment porque azure me puteaba con este error:

```
npm ERR! Windows_NT 6.2.9200
npm ERR! argv "D:\\Program Files (x86)\\nodejs\\4.1.0\\node.exe" "D:\\Program Files (x86)\\npm\\2.14.3\\node_modules\\npm\\bin\\npm-cli.js" "install" "--production"
npm ERR! node v4.1.0
npm ERR! npm  v2.14.3
npm ERR! path D:\home\site\wwwroot\node_modules\massive-operations-webjob\node_modules\azure-storage\node_modules\request\node_modules\har-validator\node_modules\is-my-json-valid\node_modules\generate-object-property\node_modules\is-property\package.json.5f4e681b35e187727dcbca355fca0a26
npm ERR! code EINVAL
npm ERR! errno -4071
npm ERR! syscall rename
 npm ERR! EINVAL: invalid argument, rename 'D:\home\site\wwwroot\node_modules\massive-operations-webjob\node_modules\azure-storage\node_modules\request\node_modules\har-validator\node_modules\is-my-json-valid\node_modules\generate-object-property\node_modules\is-property\package.json.5f4e681b35e187727dcbca355fca0a26' -> 'D:\home\site\wwwroot\node_modules\massive-operations-webjob\node_modules\azure-storage\node_modules\request\node_modules\har-validator\node_modules\is-my-json-valid\node_modules\generate-object-property\node_modules\is-property\package.json'
npm ERR! 
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>
 npm ERR! Please include the following file with any support request:
npm ERR!     D:\home\site\wwwroot\npm-debug.log
Failed exitCode=-4071, command="D:\Program Files (x86)\nodejs\4.1.0\node.exe" "D:\Program Files (x86)\npm\2.14.3\node_modules\npm\bin\npm-cli.js" install --production
An error has occurred during web site deployment.
```

No encontré por qué le agrega ese hash raro al final del _package.json_, así que tuve que COPIAR los archivos :disappointed:. Espero algún día encontrar la respuesta...
## Update

Analizando un poco con @charlyraffellini el error, que yo pensaba otra cosa, googleé un poco y **puede que sea** un bug por el largo del path :rage: que (supuestamente) se arregla con _npm@3_ que viene con _node.js_. El tema es que estamos usando una versión vieja de node que tiene una versión vieja de npm. Ahora me da un poco de paja probarlo pero lo dejo acá para la próx.
